### PR TITLE
feat: sync motion execution without wrapper

### DIFF
--- a/wandelbots/core/instance.py
+++ b/wandelbots/core/instance.py
@@ -3,6 +3,7 @@ from wandelbots.util.logger import _get_logger
 
 class Instance:
     def __init__(self, url, user=None, password=None):
+        self._api_version = "v1"
         self.user = user
         self.password = password
         self.url = self._parse_url(url)
@@ -16,16 +17,28 @@ class Instance:
                 raise ValueError("User and password are required for https connections")
         elif _url.startswith("http"):
             if self.user or self.password:
-                raise ValueError("User and password are not required for http connections")
+                raise ValueError(
+                    "User and password are not required for http connections"
+                )
         elif "wandelbots.io" in _url:
             _url = "https://" + _url
-        else: # assume http
+        else:  # assume http
             _url = "http://" + _url
         return _url
-            
+
+    @property
+    def socket_uri(self):
+        if not self.has_auth():
+            _uri = self.url.replace("http", "ws").replace("https", "wss")
+            return f"{_uri}/api/{self._api_version}"
+        else:
+            _url_no_scheme = self.url.split("://")[1]
+            _uri = f"wss://{self.user}:{self.password}@{_url_no_scheme}"
+            return f"{_uri}/api/{self._api_version}"
+
     def _connect(self):
         self.logger.info(f"Connecting to {self.url}")
         # do some connection stuff
-            
+
     def has_auth(self):
         return self.user and self.password

--- a/wandelbots/core/motiongroup.py
+++ b/wandelbots/core/motiongroup.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from typing import AsyncGenerator, Literal
+from typing import AsyncGenerator, Literal, Callable
 from contextlib import asynccontextmanager
 from wandelbots.types import MoveResponse, Pose
 
@@ -193,17 +193,30 @@ class MotionGroup:
             ):
                 pass  # Consuming the response silently
 
+    def _check_if_event_loop_is_running(self) -> bool:
+        """Check if an event loop is already running."""
+        try:
+            asyncio.get_running_loop()
+            return True
+        except RuntimeError:
+            return False
+
     def execute_motion(
         self,
         motion: str,
         speed: int,
+        response_rate_ms: int = 200,
         direction: Literal["forward", "backward"] = "forward",
+        callback: Callable[[MoveResponse], None] = None,
     ) -> None:
-        """This method is blocking and allows executing a motion synchronously
-        within a asyncio event loop."""
-        _loop = asyncio.get_event_loop()
-        _loop.run_until_complete(
-            self.execute_motion_async(motion=motion, speed=speed, direction=direction)
+        motion_api.stream_motion(
+            self.instance,
+            self.cell,
+            motion,
+            speed,
+            response_rate_ms,
+            direction,
+            callback,
         )
 
     def is_executing(self) -> bool:

--- a/wandelbots/util/logger.py
+++ b/wandelbots/util/logger.py
@@ -1,7 +1,7 @@
 import logging
 
-
-_ROOT_LOGGER_NAME = "nova"
+# TODO: Change this whenever the package name changes
+_ROOT_LOGGER_NAME = "wandelbots"
 
 
 def _get_logger(name: str):


### PR DESCRIPTION
Removes wrapper around the async motion execution method to make it work in a sync context and instead just uses `websockets.sync.client` to establish socket connection. 
