### PR TITLE
Fix code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -36,7 +36,9 @@ def check_test_motion_group_available(request):
         headers = get_auth_token()
         auth = get_basic_auth()
 
-        if "wandelbots.io" in nova_host and not headers and not auth:
+        from urllib.parse import urlparse
+        parsed_url = urlparse(nova_host)
+        if parsed_url.hostname and parsed_url.hostname.endswith(".wandelbots.io") and not headers and not auth:
             pytest.fail(
                 "Please provide NOVA_ACCESS_TOKEN or NOVA_USERNAME and NOVA_PASSWORD in the environment (depending on the used auth method)."
             )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,8 +1,10 @@
+import os
+from urllib.parse import urlparse
+
 import pytest
 import requests
-import os
-from dotenv import load_dotenv, find_dotenv
 import requests.auth
+from dotenv import find_dotenv, load_dotenv
 
 
 def get_auth_token() -> dict[str, str]:
@@ -36,9 +38,13 @@ def check_test_motion_group_available(request):
         headers = get_auth_token()
         auth = get_basic_auth()
 
-        from urllib.parse import urlparse
         parsed_url = urlparse(nova_host)
-        if parsed_url.hostname and parsed_url.hostname.endswith(".wandelbots.io") and not headers and not auth:
+        if (
+            parsed_url.hostname
+            and parsed_url.hostname.endswith(".wandelbots.io")
+            and not headers
+            and not auth
+        ):
             pytest.fail(
                 "Please provide NOVA_ACCESS_TOKEN or NOVA_USERNAME and NOVA_PASSWORD in the environment (depending on the used auth method)."
             )

--- a/wandelbots/core/instance.py
+++ b/wandelbots/core/instance.py
@@ -35,8 +35,10 @@ class Instance:
                 raise ValueError(
                     "Access token and/or user and password are not required for http connections"
                 )
-        elif "wandelbots.io" in _url:
-            _url = "https://" + _url
+        else:
+            parsed_url = urlparse(_url)
+            if parsed_url.hostname and parsed_url.hostname.endswith(".wandelbots.io"):
+                _url = "https://" + _url
         else:  # assume http
             _url = "http://" + _url
         return _url

--- a/wandelbots/core/instance.py
+++ b/wandelbots/core/instance.py
@@ -1,4 +1,4 @@
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 
 from wandelbots.util.logger import _get_logger
 
@@ -21,6 +21,7 @@ class Instance:
     def _parse_url(self, host: str) -> str:
         """remove any trailing slashes and validate scheme"""
         _url = host.rstrip("/")
+        parsed_url = urlparse(_url)
 
         if self.has_access_token() and self.has_basic_auth():
             raise ValueError("please choose either user and password or access token access")
@@ -35,10 +36,8 @@ class Instance:
                 raise ValueError(
                     "Access token and/or user and password are not required for http connections"
                 )
-        else:
-            parsed_url = urlparse(_url)
-            if parsed_url.hostname and parsed_url.hostname.endswith(".wandelbots.io"):
-                _url = "https://" + _url
+        elif parsed_url.hostname and parsed_url.hostname.endswith(".wandelbots.io"):
+            _url = "https://" + _url
         else:  # assume http
             _url = "http://" + _url
         return _url


### PR DESCRIPTION
Fixes [https://github.com/wandelbotsgmbh/wandelbots-python/security/code-scanning/1](https://github.com/wandelbotsgmbh/wandelbots-python/security/code-scanning/1)

To fix the problem, we need to ensure that the URL is properly parsed and the hostname is checked correctly. Instead of using a substring check, we should use the `urlparse` function from the `urllib.parse` module to parse the URL and then check if the hostname ends with the expected domain.

- Parse the URL using `urlparse`.
- Extract the hostname from the parsed URL.
- Check if the hostname ends with the expected domain (e.g., `.wandelbots.io`).

This change should be made in the `check_test_motion_group_available` function, specifically around the line where the substring check is performed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
